### PR TITLE
Issue #51 - Clarify doctring of `write_line_results`

### DIFF
--- a/src/Datasets.jl
+++ b/src/Datasets.jl
@@ -181,14 +181,13 @@ end
     write_line_results(output_files::Vector{String}, results, n_mc::Int64,
                        write_complete_fractions::Bool)
 
-Write line-based results to specified output ENVI raster files, including primary results,
-uncertainty estimates, and complete fractions based on provided parameters.
+Write line-based [`unmix_line`](@ref) results to specified output ENVI raster files.
 
 # Arguments
 - `output_files::Vector{String}`: File paths of the output datasets to be created or
-updated. Each entry corresponds to a separate output raster.
-- `results`: A collection of results, where each entry is expected to be a tuple or
-similar structure. Specific elements contain the data to be written to the output datasets.
+updated. The first entry is for pixel mixture fractions, subsequent entries
+are for uncertainty and complete fractions, in that order, if applicable.
+- `results`: Results to be written, as produced by [`unmix_line`](@ref).
 - `n_mc::Int64`: If greater than one, uncertainty outputs will be written to the
 subsequent output file.
 - `write_complete_fractions::Bool`: Indicates whether to write complete fractions

--- a/src/SpectralUnmixing.jl
+++ b/src/SpectralUnmixing.jl
@@ -548,8 +548,9 @@ end
                           max_combinations::Int64=-1, optimization="bvls")
 
 Unmix the specified `line` of `reflectance_file` and write the results to `output_files`.
+Workhorse function for `unmix.jl`.
 
-- Calls [`unmix_line`(@ref)] and [`write_line_results`](@ref), see for arguments.
+- See [`unmix_line`(@ref)] and [`write_line_results`](@ref) for arguments.
 """
 function unmix_and_write_line(line::Int64, reflectance_file::String, mode::String,
     refl_nodata::Float64, refl_scale::Float64, normalization::String,


### PR DESCRIPTION
Resolve #51 

Compromise that works without refactoring and creating a separate `LineResults` type which I don't think is of much use at the moment. Maybe further down the line.