### PR TITLE
Issue #59 - Install func to deploy driver script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,32 @@ A general, fast, flexible, and including spectral unmixing package.  Oriented to
 
 
 ## Installation
-This package is registered and may be added using:
+This package is registered and can be added using the Julia package manager.
+1. Install [Julia](https://julialang.org/install/)
+2. Install the package from the Julia Pkg REPL:
+```
+julia
+julia> ]
+pkg> add SpectralUnmixing
+```
+or equivalently,
 ```
 julia 'using Pkg; Pkg.add("SpectralUnmixing")'
 ```
-Remember to use the --project flag or to set the JULIA_PROJECT environment variable to activate the appropriate environment.
+Remember to activate the appropriate [environment](https://pkgdocs.julialang.org/v1/) via the Pkg REPL or by using the `--project` flag or setting the `JULIA_PROJECT` environment variable.
+3. Install the CLI script
+```
+julia> using SpectralUnmixing
+julia> CLI.install()
+```
 
-If you would like to install a local version of the repository, first pull a local copy and navigate into the base SpectralUnmixing directory.  Then run:
-
+If you would like to install a local version of the repository, first clone a local copy and navigate into the base SpectralUnmixing directory.  Then run:
 ```
 julia --project='.' -e 'using Pkg; Pkg.activate(".");'
 export JULIA_PROJECT=${PWD}
 ```
 
-## Using the script
+## Using the CLI script
 Currently the package supports reading and writing ENVI raster data.
 
 Basic:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,3 +65,8 @@ wl_index
 nanargmax
 nanargmin
 ```
+
+# CLI
+```@docs
+CLI.install
+```

--- a/src/CLI.jl
+++ b/src/CLI.jl
@@ -1,0 +1,30 @@
+module CLI
+
+export install
+
+"""
+    install(; dest_dir::String=joinpath(DEPOT_PATH[1], "bin"),
+        sym_name::String="unmix.jl")
+
+Create a symlink to the `unmix.jl` CLI script.
+
+# Arguments
+- `dest_dir::String`: The directory where the symlink will be created (default: `~/.julia/bin`).
+- `sym_name::String`: The name of the symlink to be created (default: `unmix.jl`).
+"""
+function install(; dest_dir::String=joinpath(DEPOT_PATH[1], "bin"),
+    sym_name::String="unmix.jl")
+
+    pkgpath = dirname(Base.find_package("SpectralUnmixing"))
+    src = joinpath(pkgpath, "..", "unmix.jl") |> normpath
+    dest = joinpath(dest_dir, sym_name)
+
+    mkpath(dest_dir)
+    if isfile(dest) || islink(dest)
+        rm(dest)
+    end
+    symlink(src, dest)
+    println("Symlink created at $dest")
+end
+
+end # module

--- a/src/SpectralUnmixing.jl
+++ b/src/SpectralUnmixing.jl
@@ -26,6 +26,7 @@ using LinearAlgebra
 using Combinatorics
 using Random
 
+include("CLI.jl")
 include("Datasets.jl")
 include("EndmemberLibrary.jl")
 include("Solvers.jl")
@@ -44,6 +45,9 @@ export initiate_output_datasets, set_band_names, write_results
 
 # Unmixing and simulation functions
 export unmix_line, unmix_pixel, simulate_pixel, unmix_and_write_line
+
+# CLI
+export CLI
 
 """
     wl_index(wavelengths::Vector{Float64}, target::Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ classname = "Class"
 @info "Basic CLI test"
 tmp_dir = mktempdir(@__DIR__) do dir
     @info "Creating temp directory: $dir"
+    CLI.install(dest_dir=dir, sym_name="unmix.jl")
+    unmix_jl_sym = joinpath(dir, "unmix.jl")
     output_file_base = joinpath(dir, "test_output")
     args = [
         refl_file,
@@ -19,7 +21,7 @@ tmp_dir = mktempdir(@__DIR__) do dir
         classname,
         output_file_base
     ]
-    cmd = `julia $unmix_jl $args`
+    cmd = `julia $unmix_jl_sym $args`
     @time proc = run(cmd)
     @test success(proc)
 end


### PR DESCRIPTION
Resolve #59 

Creates a function `CLI.install()` which creates a symlink of the driver script for the active version of the package in a specifiable location (defaults to `~/.julia/bin/unmix.jl`).

Now we can instruct users to install the registered package in the README simply with

```
pkg> add SpectralUnmixing
julia> using SpectralUnmixing; CLI.install()
```
